### PR TITLE
Add plugin_configs to TextField

### DIFF
--- a/bridger/serializers/fields/text.py
+++ b/bridger/serializers/fields/text.py
@@ -27,9 +27,25 @@ class TextField(CharField):
     field_type = BridgerType.TEXTEDITOR.value
     texteditor_content_type = ReturnContentType.HTML.value
 
+    def __init__(self, *args, **kwargs):
+        """The constructor method.
+        This pops the 'plugin_configs' dict from the kwargs and calls the
+        parents init method.
+
+        Parameters
+        ----------
+        plugin_configs : dict, optional
+            A dictionary that contains a dictionary for each plugin of the
+            texteditor. The configuration for each plugin must be available
+            under a unique key.
+        """
+        self.plugin_configs = kwargs.pop('plugin_configs', dict())
+        super().__init__(*args, **kwargs)
+
     def get_representation(self, request, field_name):
         representation = super().get_representation(request, field_name)
         representation["content_type"] = self.texteditor_content_type
+        representation["plugin_configs"] = self.plugin_configs
         return representation
 
 

--- a/tests/tests/test_fields/test_text_fields.py
+++ b/tests/tests/test_fields/test_text_fields.py
@@ -84,6 +84,7 @@ class TestTextField:
             "label": None,
             "type": self.field.field_type,
             "required": True,
+            "plugin_configs": {},
             "read_only": False,
             "decorators": [],
         }


### PR DESCRIPTION
This adds a 'plugin_configs' dict to the configuraion of the TextField.

This dictionary is supposed to be consumed by the frontends Text Editor and allow for extra cofiguration of the editors plugins.

The data provided in this dictionary will probably be implementation-specific to the frontends WYSIWYG Editor as it addresses specific (custom) plugins.

We might get around this by specifying the given configurations in a more general way and make the frontends editor plugins pick the information that they need.

Either way it will require one side (backend or frontend) to know about the structure that the other side provides/expects.
