### PR TITLE
Texteditor additional config

### DIFF
--- a/bridger/serializers/fields/text.py
+++ b/bridger/serializers/fields/text.py
@@ -39,13 +39,16 @@ class TextField(CharField):
             texteditor. The configuration for each plugin must be available
             under a unique key.
         """
-        self.plugin_configs = kwargs.pop('plugin_configs', dict())
+        self.plugin_configs = kwargs.pop('plugin_configs', None)
         super().__init__(*args, **kwargs)
 
     def get_representation(self, request, field_name):
         representation = super().get_representation(request, field_name)
         representation["content_type"] = self.texteditor_content_type
-        representation["plugin_configs"] = self.plugin_configs
+        if not self.plugin_configs:
+            representation["plugin_configs"] = {}
+        else:
+            representation["plugin_configs"] = self.plugin_configs(request)
         return representation
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-bridger"
-version = "0.11.9"
+version = "0.11.10"
 description = "The bridge between a Django Backend and a Javascript based Frontend"
 authors = ["Christopher Wittlinger <c.wittlinger@intellineers.com>"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-bridger"
-version = "0.11.16"
+version = "0.11.17"
 description = "The bridge between a Django Backend and a Javascript based Frontend"
 authors = ["Christopher Wittlinger <c.wittlinger@intellineers.com>"]
 


### PR DESCRIPTION
I changed the way the `plugin_config` is being added to the representation so that we can pass the request to the plugin configurations. This allows me to send an absolute URL for the in-editor templates..