### PR TITLE
Ensure field contains label and allow RepresentationSerializer to use filter_params keyword argument

### DIFF
--- a/bridger/serializers/mixins.py
+++ b/bridger/serializers/mixins.py
@@ -12,6 +12,8 @@ class RepresentationSerializerMixin:
     @classmethod
     def many_init(cls, *args, **kwargs):
         kwargs["child"] = cls()
+        if 'filter_params' in kwargs:
+            del kwargs['filter_params']
         return ListSerializer(*args, **kwargs)
 
     def __init__(self, *args, **kwargs):

--- a/bridger/serializers/serializers.py
+++ b/bridger/serializers/serializers.py
@@ -5,7 +5,7 @@ from django.db import models
 from django_fsm import FSMField
 from rest_framework import serializers
 from rest_framework.request import Request
-
+from django.utils.text import capfirst
 from bridger.fsm.mixins import FSMSerializerMetaclass
 from bridger.serializers import fields
 
@@ -73,7 +73,15 @@ class ModelSerializer(
         field_class, field_kwargs = super().build_standard_field(field_name, model_field)
         if isinstance(model_field, FSMField):
             field_class = self.serializer_fsm_field
+        if model_field and not field_kwargs.get("label", None) and model_field.verbose_name:
+            field_kwargs['label'] = capfirst(model_field.verbose_name)
+        return field_class, field_kwargs
 
+    def build_relational_field(self, field_name, relation_info):
+        field_class, field_kwargs = super().build_relational_field(field_name, relation_info)
+        model_field, related_model, to_many, to_field, has_through_model, reverse = relation_info
+        if model_field and not field_kwargs.get("label", None) and model_field.verbose_name:
+            field_kwargs['label'] = capfirst(model_field.verbose_name)
         return field_class, field_kwargs
 
     def build_property_field(self, field_name, model_class):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-bridger"
-version = "0.11.28"
+version = "0.11.30"
 description = "The bridge between a Django Backend and a Javascript based Frontend"
 authors = ["Christopher Wittlinger <c.wittlinger@intellineers.com>"]
 


### PR DESCRIPTION
Two fixes are implemented:
* Allow filter_params keyword argument to be used for Many Forward Relationship (Initially, failed at many_init)
* Fixes label not populated if verbose_name == capfirst(field_name)